### PR TITLE
Credentials in AnyKernel3 and using Proton Clang instead of Vortex Clang

### DIFF
--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -28,6 +28,8 @@ jobs:
         echo "NEED_DTBO=$(cat config.env | grep "NEED_DTBO" | head -n 1 | cut -d "=" -f 2)" >> $GITHUB_ENV
         echo "MAKE_BOOT_IMAGE=$(cat config.env | grep "MAKE_BOOT_IMAGE" | head -n 1 | cut -d "=" -f 2)" >> $GITHUB_ENV
         echo "SOURCE_BOOT_IMAGE=$(cat config.env | grep "SOURCE_BOOT_IMAGE" | head -n 1 | cut -d "=" -f 2)" >> $GITHUB_ENV
+        echo "BUILD_USER=$(cat config.env | grep "BUILD_USER" | head -n 1 | cut -d "=" -f 2)" >> $GITHUB_ENV
+        echo "BUILD_NAME=$(cat config.env | grep "BUILD_NAME" | head -n 1 | cut -d "=" -f 2)" >> $GITHUB_ENV
     - name: Setup build kernel environment
       run: |
         echo "BUILD_TIME=$(TZ=Asia/Shanghai date "+%Y%m%d%H%M")" >> $GITHUB_ENV
@@ -136,6 +138,7 @@ jobs:
         sed -i 's/do.devicecheck=1/do.devicecheck=0/g' AnyKernel3/anykernel.sh
         sed -i 's!block=/dev/block/platform/omap/omap_hsmmc.0/by-name/boot;!block=auto;!g' AnyKernel3/anykernel.sh
         sed -i 's/is_slot_device=0;/is_slot_device=auto;/g' AnyKernel3/anykernel.sh
+        sed -i 's/kernel.string=ExampleKernel by osm0sis @ xda-developers/kernel.string=$BUILD_NAME by $BUILD_USER;/g' AnyKernel3/anykernel.sh
         if [ ${{ env.CHECK_FILE_IS_OK }} = true ]; then
             cp android-kernel/out/arch/${{ env.TARGET_ARCH }}/boot/${{ env.KERNEL_FILE }} AnyKernel3/
         elif [ ${{ env.CHECK_DTBO_IS_OK }} = true ]; then

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Download Clang Toolchain
       run: |
         mkdir clang
-        git clone https://github.com/vijaymalav564/vortex-clang.git -b master --depth=1 clang
+        git clone https://github.com/kdrag0n/proton-clang.git -b master --depth=1 clang
     - name: Download mkbootimg tools
       if: env.MAKE_BOOT_IMAGE == 'true'
       run: |

--- a/.github/workflows/build-kernel.yml
+++ b/.github/workflows/build-kernel.yml
@@ -138,7 +138,7 @@ jobs:
         sed -i 's/do.devicecheck=1/do.devicecheck=0/g' AnyKernel3/anykernel.sh
         sed -i 's!block=/dev/block/platform/omap/omap_hsmmc.0/by-name/boot;!block=auto;!g' AnyKernel3/anykernel.sh
         sed -i 's/is_slot_device=0;/is_slot_device=auto;/g' AnyKernel3/anykernel.sh
-        sed -i 's/kernel.string=ExampleKernel by osm0sis @ xda-developers/kernel.string=$BUILD_NAME by $BUILD_USER;/g' AnyKernel3/anykernel.sh
+        sed -i "s/kernel.string=ExampleKernel by osm0sis @ xda-developers/kernel.string=$BUILD_NAME by $BUILD_USER;/g" AnyKernel3/anykernel.sh
         if [ ${{ env.CHECK_FILE_IS_OK }} = true ]; then
             cp android-kernel/out/arch/${{ env.TARGET_ARCH }}/boot/${{ env.KERNEL_FILE }} AnyKernel3/
         elif [ ${{ env.CHECK_DTBO_IS_OK }} = true ]; then

--- a/config.env
+++ b/config.env
@@ -7,6 +7,8 @@ EXTRA_BUILD_COMMAND:CC=clang READELF=llvm-readelf OBJCOPY=llvm-objcopy AS=llvm-a
 DISABLE-LTO=false
 USE_KERNELSU=true
 USE_KPROBES=false
+BUILD_USER=builduser
+BUILD_NAME=default
 USE_OVERLAYFS=true
 NEED_DTBO=false
 MAKE_BOOT_IMAGE=false


### PR DESCRIPTION
Changed compiler to Proton Clang (improved speed by 4 minutes in build, results may be various)
Now people can change credentials and kernel name by changing $BUILD_USER and $BUILD_NAME